### PR TITLE
Update expectEvent.js to support multiple events of the same type

### DIFF
--- a/contracts/EventEmitter.sol
+++ b/contracts/EventEmitter.sol
@@ -69,4 +69,9 @@ contract EventEmitter {
         emit String(value);
         emitter.emitStringIndirectly(value);
     }
+
+    function emitTwoLongUint(uint256 firstValue, uint256 secondValue) public {
+        emit LongUint(firstValue);
+        emit LongUint(secondValue);
+    }
 }

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -6,7 +6,7 @@ function inLogs (logs, eventName, eventArgs = {}) {
       for (const [k, v] of Object.entries(eventArgs)) {
         try {
           contains(e.args, k, v);
-        } catch {
+        } catch (ignored) {
           return false;
         }
       }

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -1,19 +1,26 @@
-const { BN, expect, should } = require('./setup');
+const { BN, expect } = require('./setup');
 
 function inLogs (logs, eventName, eventArgs = {}) {
-  const event = logs.find(function (e) {
-    if (e.event === eventName) {
-      for (const [k, v] of Object.entries(eventArgs)) {
-        try {
-          contains(e.args, k, v);
-        } catch (ignored) {
-          return false;
-        }
+  const events = logs.filter(e => e.event === eventName);
+  expect(events.length > 0).to.equal(true, `There is no '${eventName}'`);
+
+  const exception = [];
+  const event = events.find(function (e) {
+    for (const [k, v] of Object.entries(eventArgs)) {
+      try {
+        contains(e.args, k, v);
+      } catch (error) {
+        exception.push(error);
+        return false;
       }
-      return true;
     }
+    return true;
   });
-  should.exist(event);
+
+  if (event === undefined) {
+    throw exception[0];
+  }
+
   return event;
 }
 

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -4,7 +4,11 @@ function inLogs (logs, eventName, eventArgs = {}) {
   const event = logs.find(function (e) {
     if (e.event === eventName) {
       for (const [k, v] of Object.entries(eventArgs)) {
-        contains(e.args, k, v);
+        try {
+          contains(e.args, k, v);
+        } catch {
+          return false;
+        }
       }
       return true;
     }

--- a/test/src/expectEvent.test.js
+++ b/test/src/expectEvent.test.js
@@ -328,6 +328,28 @@ describe('expectEvent', function () {
       });
     });
 
+    describe('with multiple events of the same type', function () {
+      beforeEach(async function () {
+        this.firstUintValue = 42;
+        this.secondUintValue = 24;
+        ({ logs: this.logs } = await this.emitter.emitTwoLongUint(this.firstUintValue, this.secondUintValue));
+      });
+
+      it('accepts all emitted events of the same type', function () {
+        expectEvent.inLogs(this.logs, "LongUint", { value: new BN(this.firstUintValue) });
+        expectEvent.inLogs(this.logs, "LongUint", { value: new BN(this.secondUintValue) });
+      });
+
+      it('throws if an unemitted event is requested', function () {
+        should.Throw(() => expectEvent.inLogs(this.logs, "UnemittedEvent", { value: this.uintValue }));
+      });
+
+      it('throws if incorrect values are passed', function () {
+        should.Throw(() => expectEvent.inLogs(this.logs, "LongUint", { value: 41 }));
+        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 23 }));
+      });
+    });
+
     describe('with events emitted by an indirectly called contract', function () {
       beforeEach(async function () {
         this.secondEmitter = await IndirectEventEmitter.new();

--- a/test/src/expectEvent.test.js
+++ b/test/src/expectEvent.test.js
@@ -336,16 +336,16 @@ describe('expectEvent', function () {
       });
 
       it('accepts all emitted events of the same type', function () {
-        expectEvent.inLogs(this.logs, "LongUint", { value: new BN(this.firstUintValue) });
-        expectEvent.inLogs(this.logs, "LongUint", { value: new BN(this.secondUintValue) });
+        expectEvent.inLogs(this.logs, 'LongUint', { value: new BN(this.firstUintValue) });
+        expectEvent.inLogs(this.logs, 'LongUint', { value: new BN(this.secondUintValue) });
       });
 
       it('throws if an unemitted event is requested', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, "UnemittedEvent", { value: this.uintValue }));
+        should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.uintValue }));
       });
 
       it('throws if incorrect values are passed', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, "LongUint", { value: 41 }));
+        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 41 }));
         should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 23 }));
       });
     });

--- a/test/src/expectEvent.test.js
+++ b/test/src/expectEvent.test.js
@@ -345,8 +345,8 @@ describe('expectEvent', function () {
       });
 
       it('throws if incorrect values are passed', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 41 }));
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 23 }));
+        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: new BN(41) }));
+        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 24 }));
       });
     });
 


### PR DESCRIPTION
This subject is referencing issue #3, which is not implemented yet.
The feature is done by simply wrapping `contains()` function call with `try-catch`.
Let me know if there's any problem.