### PR TITLE
Remove chai autoinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,35 @@ npm install --save-dev openzeppelin-test-helpers
 ## Usage
 
 ```javascript
+// Import all required modules from openzeppelin-test-helpers
 const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+
+// Import preferred chai flavor: both expect and should are supported
+const { expect } = require('chai');
 
 const ERC20 = artifacts.require('ERC20');
 
 contract('ERC20', ([sender, receiver]) => {
   beforeEach(async function () {
     this.erc20 = ERC20.new();
-    this.value = new BN(1);
+    this.value = new BN(1); // The bundled BN library is the same one truffle and web3 use under the hood
   });
 
   it('reverts when transferring tokens to the zero address', async function () {
+    // Edge cases that trigger a require statement can be tested for, optionally checking the revert reason as well
     await shouldFail.reverting(this.erc20.transfer(constants.ZERO_ADDRESS, this.value, { from: sender }));
   });
 
   it('emits a Transfer event on successful transfers', async function () {
     const { logs } = this.erc20.transfer(receiver, this.value, { from: sender });
+    // Log-checking will not only look at the event name, but also the values, which can be addresses, strings, numbers, etc.
     expectEvent.inLogs(logs, 'Transfer', { from: sender, to: receiver, value: this.value });
   });
 
   it('updates balances on successful transfers', async function () {
     this.erc20.transfer(receiver, this.value, { from: sender });
-    (await this.token.balanceOf(receiver)).should.be.bignumber.equal(this.value);
+    // chai-bn is installed, which means BN values can be tested and compared using the bignumber property in chai
+    expect(await this.token.balanceOf(receiver)).to.be.bignumber.equal(this.value);
   });
 });
 ```

--- a/openzeppelin-test-helpers.js
+++ b/openzeppelin-test-helpers.js
@@ -1,15 +1,13 @@
-const { BN, expect, should } = require('./src/setup');
+const { BN } = require('./src/setup');
 
 module.exports = {
   balance: require('./src/balance'),
   BN,
   constants: require('./src/constants'),
   ether: require('./src/ether'),
-  expect,
   expectEvent: require('./src/expectEvent'),
   makeInterfaceId: require('./src/makeInterfaceId'),
   send: require('./src/send'),
-  should,
   shouldFail: require('./src/shouldFail'),
   singletons: require('./src/singletons'),
   time: require('./src/time'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -435,6 +441,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chai-bn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/chai-bn/-/chai-bn-0.1.1.tgz",
@@ -455,6 +475,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cipher-base": {
@@ -771,6 +797,15 @@
             "pinkie-promise": "^2.0.0"
           }
         }
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -2076,6 +2111,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3129,6 +3170,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -4076,6 +4123,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,11 +140,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -440,19 +435,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chai-bn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/chai-bn/-/chai-bn-0.1.1.tgz",
@@ -474,11 +456,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -794,14 +771,6 @@
             "pinkie-promise": "^2.0.0"
           }
         }
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -2107,11 +2076,6 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3165,11 +3129,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
-    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -4117,11 +4076,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://github.com/OpenZeppelin/openzeppelin-test-helpers#readme",
   "dependencies": {
     "ansi-colors": "^3.2.3",
-    "chai": "^4.2.0",
     "chai-bn": "^0.1.1",
     "ethjs-abi": "^0.2.1",
     "semver": "^5.6.0",
@@ -49,5 +48,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "ganache-cli": "^6.2.5",
     "truffle": "^5.0.1"
+  },
+  "peerDependencies": {
+    "chai": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "truffle-contract": "^4.0.8"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "^5.9.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -1,4 +1,5 @@
-const { BN, expect, should } = require('./setup');
+const { BN } = require('./setup');
+const { expect } = require('chai');
 
 function inLogs (logs, eventName, eventArgs = {}) {
   const event = logs.find(function (e) {
@@ -9,7 +10,7 @@ function inLogs (logs, eventName, eventArgs = {}) {
       return true;
     }
   });
-  should.exist(event);
+  expect(event).to.exist;
   return event;
 }
 
@@ -24,7 +25,7 @@ async function inTransaction (txHash, emitter, eventName, eventArgs = {}) {
 }
 
 function contains (args, key, value) {
-  (key in args).should.equal(true, `Unknown event argument '${key}'`);
+  expect(key in args).to.equal(true, `Unknown event argument '${key}'`);
 
   if (value === null) {
     expect(args[key]).to.equal(null);

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,13 +1,8 @@
 const chai = require('chai');
-
 const BN = web3.utils.BN;
 
-const should = chai
-  .use(require('chai-bn')(BN))
-  .should();
+chai.use(require('chai-bn')(BN));
 
 module.exports = {
   BN,
-  expect: chai.expect,
-  should,
 };

--- a/src/shouldFail.js
+++ b/src/shouldFail.js
@@ -1,4 +1,4 @@
-const { should } = require('./setup');
+const { expect } = require('chai');
 const colors = require('ansi-colors');
 const semver = require('semver');
 
@@ -7,12 +7,12 @@ async function shouldFailWithMessage (promise, message) {
     await promise;
   } catch (error) {
     if (message) {
-      error.message.should.include(message, `Wrong failure type, expected '${message}'`);
+      expect(error.message).to.include(message, `Wrong failure type, expected '${message}'`);
     }
     return;
   }
 
-  should.fail('Expected failure not received');
+  expect.fail('Expected failure not received');
 }
 
 async function reverting (promise) {

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -1,5 +1,3 @@
-require('./setup');
-
 const ether = require('./ether');
 const send = require('./send');
 

--- a/test-integration/ganache-core-2.1.x/package.json
+++ b/test-integration/ganache-core-2.1.x/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "truffle": "^5.0.1",
-    "ganache-cli": "6.1.0"
-  }
+    "chai": "^4.2.0",
+    "ganache-cli": "6.1.0",
+    "truffle": "^5.0.1"
+  },
+  "dependencies": {}
 }

--- a/test-integration/ganache-core-2.1.x/test.sh
+++ b/test-integration/ganache-core-2.1.x/test.sh
@@ -3,7 +3,10 @@
 # Delete the installed dependency
 rm -rf node_modules/openzeppelin-test-helpers
 # Replace it with the local package
-ln -s ../../.. node_modules/openzeppelin-test-helpers
+mkdir -p node_modules/openzeppelin-test-helpers/src
+cp -r ../../openzeppelin-test-helpers.js node_modules/openzeppelin-test-helpers/
+cp -r ../../package.json node_modules/openzeppelin-test-helpers/
+cp -r ../../src/* node_modules/openzeppelin-test-helpers/src/
 
 # Exit script as soon as a command fails.
 set -o errexit

--- a/test-integration/ganache-core-2.1.x/test/Tested.test.js
+++ b/test-integration/ganache-core-2.1.x/test/Tested.test.js
@@ -1,4 +1,5 @@
 const { shouldFail } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const Tested = artifacts.require('Tested');
 
@@ -14,13 +15,13 @@ contract('Tested', function (accounts) {
         const expectedMessage = 'lorem ipsum';
         // Asserting that locally installed ganache-core is v2.1.0.
         const nodeInfo = await web3.eth.getNodeInfo();
-        nodeInfo.should.include('2.1.0');
+        expect(nodeInfo).to.include('2.1.0');
         try {
           await this.contract.failWithRevertReason();
         }
         catch (error) {
           // Asserting that older ganache does NOT return reason message.
-          error.message.should.not.include(expectedMessage);
+          expect(error.message).to.not.include(expectedMessage);
         }
         // With that said, following revert should be accepted without regard to the specified
         // reason message.

--- a/test-integration/simple-project-truffle-5.x/package.json
+++ b/test-integration/simple-project-truffle-5.x/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "chai": "^4.2.0",
     "truffle": "^5.0.1"
   }
 }

--- a/test-integration/simple-project-truffle-5.x/test.sh
+++ b/test-integration/simple-project-truffle-5.x/test.sh
@@ -2,7 +2,11 @@
 
 # Delete the installed dependency
 rm -rf node_modules/openzeppelin-test-helpers
+
 # Replace it with the local package
-ln -s ../../.. node_modules/openzeppelin-test-helpers
+mkdir -p node_modules/openzeppelin-test-helpers/src
+cp -r ../../openzeppelin-test-helpers.js node_modules/openzeppelin-test-helpers/
+cp -r ../../package.json node_modules/openzeppelin-test-helpers/
+cp -r ../../src/* node_modules/openzeppelin-test-helpers/src/
 
 npx truffle test

--- a/test-integration/simple-project-truffle-5.x/test/accounts.test.js
+++ b/test-integration/simple-project-truffle-5.x/test/accounts.test.js
@@ -1,10 +1,11 @@
 const { balance, BN, ether, send } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 contract('accounts', function (accounts) {
   it('sends ether and tracks balances', async function () {
     const value = ether('42', 'ether');
     const tracker = await balance.tracker(accounts[0]);
     await send.ether(accounts[0], accounts[1], value);
-    (await tracker.delta()).should.be.bignumber.equals(value.neg());
+    expect(await tracker.delta()).to.be.bignumber.equals(value.neg());
   });
 });

--- a/test/src/balance.test.js
+++ b/test/src/balance.test.js
@@ -1,4 +1,5 @@
 require('../../src/setup');
+const { expect } = require('chai');
 
 const balance = require('../../src/balance');
 const send = require('../../src/send');
@@ -7,21 +8,21 @@ const ether = require('../../src/ether');
 contract('balance', function ([sender, receiver]) {
   describe('current', function () {
     it('returns the current balance of an account as a BN', async function () {
-      (await balance.current(sender)).should.be.bignumber.equal(await web3.eth.getBalance(sender));
+      expect(await balance.current(sender)).to.be.bignumber.equal(await web3.eth.getBalance(sender));
     });
   });
 
   describe('balance tracker', function () {
     it('returns current balance ', async function () {
       const tracker = await balance.tracker(receiver);
-      (await tracker.get()).should.be.bignumber.equal(await web3.eth.getBalance(receiver));
+      expect(await tracker.get()).to.be.bignumber.equal(await web3.eth.getBalance(receiver));
     });
 
     it('get() adds a new checkpoint ', async function () {
       const tracker = await balance.tracker(sender);
       await send.ether(sender, receiver, ether('1'));
       await tracker.get();
-      (await tracker.delta()).should.be.bignumber.equal('0');
+      expect(await tracker.delta()).to.be.bignumber.equal('0');
     });
 
     it('returns correct deltas after get() checkpoint', async function () {
@@ -29,26 +30,26 @@ contract('balance', function ([sender, receiver]) {
       await send.ether(sender, receiver, ether('1'));
       await tracker.get();
       await send.ether(sender, receiver, ether('1'));
-      (await tracker.delta()).should.be.bignumber.equal(ether('1'));
+      expect(await tracker.delta()).to.be.bignumber.equal(ether('1'));
     });
 
     it('returns balance increments', async function () {
       const tracker = await balance.tracker(receiver);
       await send.ether(sender, receiver, ether('1'));
-      (await tracker.delta()).should.be.bignumber.equal(ether('1'));
+      expect(await tracker.delta()).to.be.bignumber.equal(ether('1'));
     });
 
     it('returns balance decrements', async function () {
       const tracker = await balance.tracker(sender);
       await send.ether(sender, receiver, ether('1'));
-      (await tracker.delta()).should.be.bignumber.equal(ether('-1'));
+      expect(await tracker.delta()).to.be.bignumber.equal(ether('-1'));
     });
 
     it('returns consecutive deltas', async function () {
       const tracker = await balance.tracker(sender);
       await send.ether(sender, receiver, ether('1'));
       await tracker.delta();
-      (await tracker.delta()).should.be.bignumber.equal('0');
+      expect(await tracker.delta()).to.be.bignumber.equal('0');
     });
   });
 });

--- a/test/src/ether.test.js
+++ b/test/src/ether.test.js
@@ -1,12 +1,13 @@
 const { BN } = require('../../src/setup');
+const { expect } = require('chai');
 const ether = require('../../src/ether');
 
 describe('ether', function () {
   it('returns a BN', function () {
-    ether('1').should.be.bignumber.equal(new BN('1000000000000000000'));
+    expect(ether('1')).to.be.bignumber.equal(new BN('1000000000000000000'));
   });
 
   it('works with negative amounts', function () {
-    ether('-1').should.be.bignumber.equal(new BN('-1000000000000000000'));
+    expect(ether('-1')).to.be.bignumber.equal(new BN('-1000000000000000000'));
   });
 });

--- a/test/src/expectEvent.test.js
+++ b/test/src/expectEvent.test.js
@@ -342,12 +342,12 @@ describe('expectEvent', function () {
       });
 
       it('throws if an unemitted event is requested', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.uintValue }));
+        expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.uintValue })).to.throw();
       });
 
       it('throws if incorrect values are passed', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: new BN(41) }));
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 24 }));
+        expect(() => expectEvent.inLogs(this.logs, 'LongUint', { value: new BN(41) })).to.throw();
+        expect(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 24 })).to.throw();
       });
     });
 

--- a/test/src/expectEvent.test.js
+++ b/test/src/expectEvent.test.js
@@ -1,4 +1,5 @@
-const { BN, should } = require('../../src/setup');
+const { BN } = require('../../src/setup');
+const { expect } = require('chai');
 const expectEvent = require('../../src/expectEvent');
 const shouldFail = require('../../src/shouldFail');
 
@@ -77,7 +78,7 @@ describe('expectEvent', function () {
       });
 
       it('throws if an unemitted event is requested', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent'));
+        expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent')).to.throw();
       });
     });
 
@@ -93,19 +94,19 @@ describe('expectEvent', function () {
         });
 
         it('throws if an emitted event with correct JavaScript number is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'ShortUint', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'ShortUint', { value: this.value })).to.throw();
         });
 
         it('throws if an emitted event with correct BN and incorrect name is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'ShortUint', { number: new BN(this.value) }));
+          expect(() => expectEvent.inLogs(this.logs, 'ShortUint', { number: new BN(this.value) })).to.throw();
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'ShortUint', { value: 23 }));
+          expect(() => expectEvent.inLogs(this.logs, 'ShortUint', { value: 23 })).to.throw();
         });
       });
 
@@ -120,15 +121,15 @@ describe('expectEvent', function () {
         });
 
         it('throws if an emitted event with correct JavaScript number is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'ShortInt', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'ShortInt', { value: this.value })).to.throw();
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'ShortInt', { value: -23 }));
+          expect(() => expectEvent.inLogs(this.logs, 'ShortInt', { value: -23 })).to.throw();
         });
       });
 
@@ -143,11 +144,11 @@ describe('expectEvent', function () {
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.bigNumValue }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.bigNumValue })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 2300 }));
+          expect(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 2300 })).to.throw();
         });
       });
 
@@ -162,11 +163,11 @@ describe('expectEvent', function () {
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.bigNumValue }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.bigNumValue })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'LongInt', { value: -2300 }));
+          expect(() => expectEvent.inLogs(this.logs, 'LongInt', { value: -2300 })).to.throw();
         });
       });
 
@@ -181,13 +182,13 @@ describe('expectEvent', function () {
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() =>
+          expect(() =>
             expectEvent.inLogs(this.logs, 'Address', { value: '0x21d04e022e0b52b5d5bcf90b7f1aabf406be002d' })
-          );
+          ).to.throw();
         });
       });
 
@@ -202,11 +203,11 @@ describe('expectEvent', function () {
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'Boolean', { value: false }));
+          expect(() => expectEvent.inLogs(this.logs, 'Boolean', { value: false })).to.throw();
         });
       });
 
@@ -221,11 +222,11 @@ describe('expectEvent', function () {
         });
 
         it('throws if an unemitted event is requested', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+          expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
         });
 
         it('throws if an incorrect value is passed', function () {
-          should.Throw(() => expectEvent.inLogs(this.logs, 'String', { value: 'ClosedZeppelin' }));
+          expect(() => expectEvent.inLogs(this.logs, 'String', { value: 'ClosedZeppelin' })).to.throw();
         });
       });
 
@@ -241,11 +242,11 @@ describe('expectEvent', function () {
           });
 
           it('throws if an unemitted event is requested', function () {
-            should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value }));
+            expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.value })).to.throw();
           });
 
           it('throws if an incorrect value is passed', function () {
-            should.Throw(() => expectEvent.inLogs(this.logs, 'Bytes', { value: '0x123456' }));
+            expect(() => expectEvent.inLogs(this.logs, 'Bytes', { value: '0x123456' })).to.throw();
           });
         });
 
@@ -260,11 +261,11 @@ describe('expectEvent', function () {
           });
 
           it('throws if an unemitted event is requested', function () {
-            should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: null }));
+            expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: null })).to.throw();
           });
 
           it('throws if an incorrect value is passed', function () {
-            should.Throw(() => expectEvent.inLogs(this.logs, 'Bytes', { value: '0x123456' }));
+            expect(() => expectEvent.inLogs(this.logs, 'Bytes', { value: '0x123456' })).to.throw();
           });
         });
       });
@@ -286,23 +287,23 @@ describe('expectEvent', function () {
       });
 
       it('throws with correct values assigned to wrong arguments', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
+        expect(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
           uintValue: this.booleanValue, booleanValue: this.uintValue, stringValue: this.stringValue,
-        }));
+        })).to.throw();
       });
 
       it('throws when any of the values is incorrect', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
+        expect(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
           uintValue: 23, booleanValue: this.booleanValue, stringValue: this.stringValue,
-        }));
+        })).to.throw();
 
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
+        expect(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
           uintValue: this.uintValue, booleanValue: false, stringValue: this.stringValue,
-        }));
+        })).to.throw();
 
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
+        expect(() => expectEvent.inLogs(this.logs, 'LongUintBooleanString', {
           uintValue: this.uintValue, booleanValue: this.booleanValue, stringValue: 'ClosedZeppelin',
-        }));
+        })).to.throw();
       });
     });
 
@@ -319,12 +320,12 @@ describe('expectEvent', function () {
       });
 
       it('throws if an unemitted event is requested', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.uintValue }));
+        expect(() => expectEvent.inLogs(this.logs, 'UnemittedEvent', { value: this.uintValue })).to.throw();
       });
 
       it('throws if incorrect values are passed', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 23 }));
-        should.Throw(() => expectEvent.inLogs(this.logs, 'Boolean', { value: false }));
+        expect(() => expectEvent.inLogs(this.logs, 'LongUint', { value: 23 })).to.throw();
+        expect(() => expectEvent.inLogs(this.logs, 'Boolean', { value: false })).to.throw();
       });
     });
 
@@ -341,7 +342,7 @@ describe('expectEvent', function () {
       });
 
       it('throws when passing events emitted by the indirectly called contract', function () {
-        should.Throw(() => expectEvent.inLogs(this.logs, 'IndirectString', { value: this.value }));
+        expect(() => expectEvent.inLogs(this.logs, 'IndirectString', { value: this.value })).to.throw();
       });
     });
   });

--- a/test/src/makeInterfaceId.test.js
+++ b/test/src/makeInterfaceId.test.js
@@ -1,4 +1,5 @@
 require('../../src/setup');
+const { expect } = require('chai');
 const makeInterfaceId = require('../../src/makeInterfaceId');
 
 const OwnableInterfaceId = artifacts.require('OwnableInterfaceId');
@@ -8,11 +9,11 @@ describe('makeInterfaceId', function () {
     const calculator = await OwnableInterfaceId.new();
     const ownableId = await calculator.getInterfaceId();
 
-    makeInterfaceId([
+    expect(makeInterfaceId([
       'owner()',
       'isOwner()',
       'renounceOwnership()',
       'transferOwnership(address)',
-    ]).should.equal(ownableId);
+    ])).to.equal(ownableId);
   });
 });

--- a/test/src/send.test.js
+++ b/test/src/send.test.js
@@ -1,4 +1,5 @@
 const { BN } = require('../../src/setup');
+const { expect } = require('chai');
 const send = require('../../src/send');
 const shouldFail = require('../../src/shouldFail');
 const expectEvent = require('../../src/expectEvent');
@@ -19,8 +20,8 @@ contract('send', function ([sender, receiver]) {
       const finalSenderBalance = new BN(await web3.eth.getBalance(sender));
       const finalReceiverBalance = new BN(await web3.eth.getBalance(receiver));
 
-      finalSenderBalance.sub(initialSenderBalance).should.be.bignumber.equal(value.neg());
-      finalReceiverBalance.sub(initialReceiverBalance).should.be.bignumber.equal(value);
+      expect(finalSenderBalance.sub(initialSenderBalance)).to.be.bignumber.equal(value.neg());
+      expect(finalReceiverBalance.sub(initialReceiverBalance)).to.be.bignumber.equal(value);
     });
 
     it('throws if the sender balance is insufficient', async function () {

--- a/test/src/shouldFail.test.js
+++ b/test/src/shouldFail.test.js
@@ -1,4 +1,4 @@
-const { should } = require('../../src/setup');
+const { expect } = require('chai');
 const shouldFail = require('../../src/shouldFail');
 
 const Failer = artifacts.require('Failer');
@@ -9,7 +9,7 @@ async function assertFailure (promise) {
   } catch (error) {
     return;
   }
-  should.fail();
+  expect.fail();
 }
 
 describe('shouldFail', function () {

--- a/test/src/singletons.test.js
+++ b/test/src/singletons.test.js
@@ -1,4 +1,4 @@
-require('../../src/setup');
+const { expect } = require('chai');
 const singletons = require('../../src/singletons');
 const { ERC1820_REGISTRY_BYTECODE } = require('../../src/data');
 
@@ -9,20 +9,20 @@ contract('singletons', function ([funder]) {
     });
 
     it('returns a truffle-contract instance', function () {
-      this.registry.constructor.name.should.equal('TruffleContract');
+      expect(this.registry.constructor.name).to.equal('TruffleContract');
     });
 
     it('the registry is stored at the correct address', function () {
-      this.registry.address.should.equal('0x1820b744B33945482C17Dc37218C01D858EBc714');
+      expect(this.registry.address).to.equal('0x1820b744B33945482C17Dc37218C01D858EBc714');
     });
 
     it('stores the correct code at the registry address', async function () {
-      (await web3.eth.getCode(this.registry.address)).should.equal(ERC1820_REGISTRY_BYTECODE);
+      expect((await web3.eth.getCode(this.registry.address))).to.equal(ERC1820_REGISTRY_BYTECODE);
     });
 
     it('returns the same truffle-contract when attempting to deploy a second registry', async function () {
       const newRegistry = await singletons.ERC1820Registry(funder);
-      newRegistry.address.should.equal('0x1820b744B33945482C17Dc37218C01D858EBc714');
+      expect(newRegistry.address).to.equal('0x1820b744B33945482C17Dc37218C01D858EBc714');
     });
   });
 });

--- a/test/src/time.test.js
+++ b/test/src/time.test.js
@@ -1,5 +1,5 @@
 const { BN } = require('../../src/setup');
-
+const { expect } = require('chai');
 const time = require('../../src/time');
 const shouldFail = require('../../src/shouldFail');
 
@@ -8,33 +8,33 @@ describe('time', function () {
 
   describe('duration', function () {
     it('converts seconds to seconds', function () {
-      time.duration.seconds(1).should.be.bignumber.equal(new BN(1));
+      expect(time.duration.seconds(1)).to.be.bignumber.equal(new BN(1));
     });
 
     it('converts minutes to seconds', function () {
-      time.duration.minutes(1).should.be.bignumber.equal(new BN(60));
+      expect(time.duration.minutes(1)).to.be.bignumber.equal(new BN(60));
     });
 
     it('converts hours to seconds', function () {
-      time.duration.hours(1).should.be.bignumber.equal(new BN(60 * 60));
+      expect(time.duration.hours(1)).to.be.bignumber.equal(new BN(60 * 60));
     });
 
     it('converts days to seconds', function () {
-      time.duration.days(1).should.be.bignumber.equal(new BN(60 * 60 * 24));
+      expect(time.duration.days(1)).to.be.bignumber.equal(new BN(60 * 60 * 24));
     });
 
     it('converts weeks to seconds', function () {
-      time.duration.weeks(1).should.be.bignumber.equal(new BN(60 * 60 * 24 * 7));
+      expect(time.duration.weeks(1)).to.be.bignumber.equal(new BN(60 * 60 * 24 * 7));
     });
 
     it('converts years to seconds', function () {
-      time.duration.years(1).should.be.bignumber.equal(new BN(60 * 60 * 24 * 365));
+      expect(time.duration.years(1)).to.be.bignumber.equal(new BN(60 * 60 * 24 * 365));
     });
   });
 
   describe('latestBlock', function () {
     it('returns a BN with the current block number', async function () {
-      (await time.latestBlock()).should.be.bignumber.equal(new BN(await web3.eth.getBlockNumber()));
+      expect(await time.latestBlock()).to.be.bignumber.equal(new BN(await web3.eth.getBlockNumber()));
     });
   });
 
@@ -42,13 +42,13 @@ describe('time', function () {
     it('increases the block number by one', async function () {
       const startingBlock = await time.latestBlock();
       await time.advanceBlock();
-      (await time.latestBlock()).should.be.bignumber.equal(startingBlock.add(new BN(1)));
+      expect(await time.latestBlock()).to.be.bignumber.equal(startingBlock.add(new BN(1)));
     });
   });
 
   describe('latest', function () {
     it('returns a BN', async function () {
-      (await time.latest()).should.be.bignumber.equal(await time.latest()); // Hacky, but this triggers BN type check
+      expect(await time.latest()).to.be.bignumber.equal(await time.latest()); // Hacky, but this triggers BN type check
     });
   });
 
@@ -65,7 +65,7 @@ describe('time', function () {
         const end = this.start.add(time.duration.hours(1));
 
         const now = await time.latest();
-        now.should.be.bignumber.closeTo(end, TOLERANCE_SECONDS);
+        expect(now).to.be.bignumber.closeTo(end, TOLERANCE_SECONDS);
       });
 
       it('throws with negative durations', async function () {
@@ -79,7 +79,7 @@ describe('time', function () {
         await time.increaseTo(end);
 
         const now = await time.latest();
-        now.should.be.bignumber.closeTo(end, TOLERANCE_SECONDS);
+        expect(now).to.be.bignumber.closeTo(end, TOLERANCE_SECONDS);
       });
 
       it('throws with a time in the past', async function () {


### PR DESCRIPTION
With this change, `chai` needs to be explicitly `require`d by users if they want to use it. Additionally, `chai.should()` is no longer called, which may have been a bit intrusive.