### PR TITLE
Fix shouldFail.reverting.withMessage on non-Ganache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0 (unreleased)
+ * Fix `shouldFail.reverting.withMessage` on non-Ganache chains. ([#25](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/25)
+
 ## 0.3.1 (2019-04-01)
  * Add support for environments using `web3-provider-engine`. ([#24](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/24))
 

--- a/src/shouldFail.js
+++ b/src/shouldFail.js
@@ -36,13 +36,21 @@ async function withMessage (promise, message) {
   // https://github.com/trufflesuite/ganache-core/releases/tag/v2.2.0
   const nodeInfo = await web3.eth.getNodeInfo();
   const matches = /TestRPC\/v([0-9.]+)\/ethereum-js/.exec(nodeInfo);
-  if (1 in matches && semver.satisfies(matches[1], '>=2.2.0')) {
-    return shouldFailWithMessage(promise, message);
-  } else {
-    // Otherwise, warn users and skip reason check.
+  const warn = function (msg) {
     console.log(`${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} \
-shouldFail.reverting.withMessage: current version of Ganache (${matches[1]}) doesn't return revert reason.`);
+shouldFail.reverting.withMessage: ` + msg);
+  };
+  if (matches === null || !(1 in matches)) {
+    // warn users and skip reason check.
+    warn('revert reason checking only supported on Ganache>=2.2.0');
     return shouldFailWithMessage(promise);
+  } else if (!semver.satisfies(matches[1], '>=2.2.0')) {
+    // warn users and skip reason check.
+    warn(`current version of Ganache (${matches[1]}) doesn't return revert reason.`);
+    return shouldFailWithMessage(promise);
+  } else {
+    // actually perform revert reason check.
+    return shouldFailWithMessage(promise, message);
   }
 }
 


### PR DESCRIPTION
Currently `shouldFail.reverting.withMessage` tries to execute the following
regular expression match:
```
/TestRPC\/v([0-9.]+)\/ethereum-js/.exec(web3ClientVersion)
```

When `web3ClientVersion` has a value like
`Geth/v1.8.9-unstable-d4ac250e/linux-amd64/go1.9.4`,
which would likely occur when testing against any non-Ganache
chain implementation, `RegExp.prototype.exec()` would return `null`
causing an error like:
```
TypeError: Cannot use 'in' operator to search for '1' in null
```
when `1 in matches` is evaluated in the subsequent code.

This patch fixes things by testing for `matches` being `null` or
`matches[1]` not being valid explicitly.

Tested with `npm run test` and `npm run test-integration`.