### PR TITLE
shouldFail.reverting.withMessage fails if no error string is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0 (unreleased)
  * Fix `shouldFail.reverting.withMessage` on non-Ganache chains. ([#25](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/25)
+ * `shouldFail.reverting.withMessage` fails if no error string is provided. ([#28](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/28)
 
 ## 0.3.2 (2019-04-10)
  * Update ERC1820Registry address. ([#26](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/26))

--- a/src/shouldFail.js
+++ b/src/shouldFail.js
@@ -8,6 +8,8 @@ async function shouldFailWithMessage (promise, message) {
   } catch (error) {
     if (message) {
       expect(error.message).to.include(message, `Wrong failure type, expected '${message}'`);
+    } else {
+      expect.fail('Message not provided');
     }
     return;
   }
@@ -28,7 +30,12 @@ async function outOfGas (promise) {
 }
 
 async function shouldFail (promise) {
-  await shouldFailWithMessage(promise);
+  try {
+    await promise;
+  } catch (error) {
+    return;
+  }
+  expect.fail('Failure not received');
 }
 
 async function withMessage (promise, message) {
@@ -43,11 +50,11 @@ shouldFail.reverting.withMessage: ` + msg);
   if (matches === null || !(1 in matches)) {
     // warn users and skip reason check.
     warn('revert reason checking only supported on Ganache>=2.2.0');
-    return shouldFailWithMessage(promise);
+    return shouldFail(promise);
   } else if (!semver.satisfies(matches[1], '>=2.2.0')) {
     // warn users and skip reason check.
     warn(`current version of Ganache (${matches[1]}) doesn't return revert reason.`);
-    return shouldFailWithMessage(promise);
+    return shouldFail(promise);
   } else {
     // actually perform revert reason check.
     return shouldFailWithMessage(promise, message);

--- a/test/src/shouldFail.test.js
+++ b/test/src/shouldFail.test.js
@@ -73,6 +73,10 @@ describe('shouldFail', function () {
         await assertFailure(shouldFail.reverting.withMessage(this.failer.failWithRevertReason(), 'Wrong reason'));
       });
 
+      it('rejects if no reason string passed', async function () {
+        await assertFailure(shouldFail.reverting.withMessage(this.failer.failWithRevertReason()));
+      });
+
       it('accepts require() revert with an expected reason', async function () {
         await shouldFail.reverting.withMessage(this.failer.failRequirementWithReason(), 'Unsatisfied');
       });


### PR DESCRIPTION
`shouldFail.reverting.withMessage` will be used when there is error string involved. In other cases, `shouldFail` can work. 

Fixes #27