### PR TITLE
send.transaction works with fallback too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0 (unreleased)
  * Fix `shouldFail.reverting.withMessage` on non-Ganache chains. ([#25](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/25)
+ * Fix `send.transaction` not working on contracts with a fallback function. ([#26](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/26)
 
 ## 0.3.2 (2019-04-10)
  * Update ERC1820Registry address. ([#26](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/26))

--- a/contracts/Acknowledger.sol
+++ b/contracts/Acknowledger.sol
@@ -18,7 +18,7 @@ contract Acknowledger {
         emit AcknowledgeBarDouble(a, b);
     }
 
-    function () {
+    function () external {
         emit AcknowledgeFallback();
     }
 }

--- a/contracts/Acknowledger.sol
+++ b/contracts/Acknowledger.sol
@@ -4,6 +4,7 @@ contract Acknowledger {
     event AcknowledgeFoo(uint256 a);
     event AcknowledgeBarSingle(uint256 a);
     event AcknowledgeBarDouble(uint256 a, uint256 b);
+    event AcknowledgeFallback();
 
     function foo(uint256 a) public {
         emit AcknowledgeFoo(a);
@@ -15,5 +16,9 @@ contract Acknowledger {
 
     function bar(uint256 a, uint256 b) public {
         emit AcknowledgeBarDouble(a, b);
+    }
+
+    function () {
+        emit AcknowledgeFallback();
     }
 }

--- a/src/send.js
+++ b/src/send.js
@@ -2,17 +2,23 @@ const ethjsABI = require('ethjs-abi');
 
 function findMethod (abi, name, args) {
   for (let i = 0; i < abi.length; i++) {
-    const methodArgs = abi[i].inputs.map(input => input.type).join(',');
-    if ((abi[i].name === name) && (methodArgs === args)) {
-      return abi[i];
+    if (abi[i].type === 'function') {
+      const methodArgs = abi[i].inputs.map(input => input.type).join(',');
+      if ((abi[i].name === name) && (methodArgs === args)) {
+        return abi[i];
+      }
     }
   }
 }
 
 async function transaction (target, name, argsTypes, argsValues, opts = {}) {
-  const abiMethod = findMethod(target.abi, name, argsTypes);
-  const encodedData = ethjsABI.encodeMethod(abiMethod, argsValues);
-
+  let encodedData;
+  if (name === '') {
+    encodedData = '0x';
+  } else {
+    const abiMethod = findMethod(target.abi, name, argsTypes);
+    encodedData = ethjsABI.encodeMethod(abiMethod, argsValues);
+  }
   opts.from = opts.from || (await web3.eth.getAccounts())[0];
   return web3.eth.sendTransaction({ data: encodedData, to: target.address, ...opts });
 }

--- a/src/send.js
+++ b/src/send.js
@@ -12,14 +12,11 @@ function findMethod (abi, name, args) {
 }
 
 async function transaction (target, name, argsTypes, argsValues, opts = {}) {
-  let encodedData;
-  if (name === '') {
-    encodedData = '0x';
-  } else {
-    const abiMethod = findMethod(target.abi, name, argsTypes);
-    encodedData = ethjsABI.encodeMethod(abiMethod, argsValues);
-  }
+  const abiMethod = findMethod(target.abi, name, argsTypes);
+  const encodedData = ethjsABI.encodeMethod(abiMethod, argsValues);
+
   opts.from = opts.from || (await web3.eth.getAccounts())[0];
+
   return web3.eth.sendTransaction({ data: encodedData, to: target.address, ...opts });
 }
 

--- a/test/src/send.test.js
+++ b/test/src/send.test.js
@@ -29,6 +29,14 @@ contract('send', function ([sender, receiver]) {
 
       await shouldFail(send.ether(sender, receiver, value));
     });
+
+    it('calls fallback function', async function () {
+      this.acknowledger = await Acknowledger.new();
+      const receipt = await send.ether(sender, this.acknowledger.address, 0);
+      await expectEvent.inTransaction(
+        receipt.transactionHash, Acknowledger, 'AcknowledgeFallback'
+      );
+    });
   });
 
   describe('transaction', function () {
@@ -59,13 +67,6 @@ contract('send', function ([sender, receiver]) {
         const receipt = await send.transaction(this.acknowledger, 'bar', 'uint256,uint256', [3, 5], opts);
         await expectEvent.inTransaction(
           receipt.transactionHash, Acknowledger, 'AcknowledgeBarDouble', { a: '3', b: '5' }
-        );
-      });
-
-      it('calls fallback function', async function () {
-        const receipt = await send.transaction(this.acknowledger, '', '', [], opts);
-        await expectEvent.inTransaction(
-          receipt.transactionHash, Acknowledger, 'AcknowledgeFallback'
         );
       });
 

--- a/test/src/send.test.js
+++ b/test/src/send.test.js
@@ -62,6 +62,13 @@ contract('send', function ([sender, receiver]) {
         );
       });
 
+      it('calls fallback function', async function () {
+        const receipt = await send.transaction(this.acknowledger, '', '', [], opts);
+        await expectEvent.inTransaction(
+          receipt.transactionHash, Acknowledger, 'AcknowledgeFallback'
+        );
+      });
+
       it('throws if the number of arguments does not match', async function () {
         await shouldFail(send.transaction(this.acknowledger, 'foo', 'uint256, uint256', [3, 5]), opts);
       });


### PR DESCRIPTION
for fallback, no function name will be passed.

fixes #6 