### PR TITLE
Add simple documentation of constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ A [bn.js](https://github.com/indutny/bn.js) object. Use `new BN(number)` to crea
 
 ---
 
+### constants
+A collection of useful [constants](src/constants.js).
+
+---
+
 ### ether
 Converts a value in Ether to wei.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ A [bn.js](https://github.com/indutny/bn.js) object. Use `new BN(number)` to crea
 ### constants
 A collection of useful [constants](src/constants.js).
 
+#### constants.ZERO_ADDRESS
+The initial value of a type `address` variable, i.e., `address(0)` in Solidity.
+
+#### constants.MAX_UINT256
+The maximum unsigned integer `2^256 - 1` represented in `BN`.
+
+#### constants.MAX_INT256
+The maximum signed integer `2^255 -1` represented in `BN`.
+
+#### constants.MIN_INT256
+The minimum signed integer `-2^255` represented in `BN`.
+
 ---
 
 ### ether

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The initial value of a type `address` variable, i.e., `address(0)` in Solidity.
 The maximum unsigned integer `2^256 - 1` represented in `BN`.
 
 #### constants.MAX_INT256
-The maximum signed integer `2^255 -1` represented in `BN`.
+The maximum signed integer `2^255 - 1` represented in `BN`.
 
 #### constants.MIN_INT256
 The minimum signed integer `-2^255` represented in `BN`.


### PR DESCRIPTION
This is to resolve #31. 

Not sure if it's necessary to document every constant in README, so I simply mention the existence of `constants`module and link it to the actual file for reference.