### PR TITLE
Update contracts to compile using 0.5.8.

### DIFF
--- a/contracts/Acknowledger.sol
+++ b/contracts/Acknowledger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract Acknowledger {
     event AcknowledgeFoo(uint256 a);

--- a/contracts/EventEmitter.sol
+++ b/contracts/EventEmitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "./IndirectEventEmitter.sol";
 
@@ -14,7 +14,7 @@ contract EventEmitter {
     event LongUintBooleanString(uint256 uintValue, bool booleanValue, string stringValue);
     event Bytes(bytes value);
 
-    constructor (uint8 uintValue, bool booleanValue, string stringValue) public {
+    constructor (uint8 uintValue, bool booleanValue, string memory stringValue) public {
         emit ShortUint(uintValue);
         emit Boolean(booleanValue);
         emit String(stringValue);
@@ -48,7 +48,7 @@ contract EventEmitter {
         emit Boolean(value);
     }
 
-    function emitString(string value) public {
+    function emitString(string memory value) public {
         emit String(value);
     }
 
@@ -56,7 +56,7 @@ contract EventEmitter {
         emit Bytes(value);
     }
 
-    function emitLongUintBooleanString(uint256 uintValue, bool booleanValue, string stringValue) public {
+    function emitLongUintBooleanString(uint256 uintValue, bool booleanValue, string memory stringValue) public {
         emit LongUintBooleanString(uintValue, booleanValue, stringValue);
     }
 
@@ -65,7 +65,7 @@ contract EventEmitter {
         emit Boolean(boolValue);
     }
 
-    function emitStringAndEmitIndirectly(string value, IndirectEventEmitter emitter) public {
+    function emitStringAndEmitIndirectly(string memory value, IndirectEventEmitter emitter) public {
         emit String(value);
         emitter.emitStringIndirectly(value);
     }

--- a/contracts/IndirectEventEmitter.sol
+++ b/contracts/IndirectEventEmitter.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract IndirectEventEmitter {
     event IndirectString(string value);
 
-    function emitStringIndirectly(string value) public {
+    function emitStringIndirectly(string memory value) public {
         emit IndirectString(value);
     }
 }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract Ownable {
     address private _owner;

--- a/contracts/OwnableInterfaceId.sol
+++ b/contracts/OwnableInterfaceId.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "./Ownable.sol";
 

--- a/contracts/Reverter.sol
+++ b/contracts/Reverter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract Reverter {
     uint256[] private array;
@@ -20,10 +20,6 @@ contract Reverter {
 
     function revertFromRequireWithReason() public pure {
         require(false, "Failed requirement");
-    }
-
-    function revertFromThrow() public pure {
-        throw;
     }
 
     function revertFromAssert() public pure {

--- a/test/src/expectRevert.test.js
+++ b/test/src/expectRevert.test.js
@@ -45,10 +45,6 @@ describe('expectRevert', function () {
       await expectRevert(this.reverter.revertFromRequireWithReason(), 'Failed requirement');
     });
 
-    it('rejects a throw', async function () {
-      await assertFailure(expectRevert(this.reverter.revertFromThrow()));
-    });
-
     it('rejects a failed assertion', async function () {
       await assertFailure(expectRevert(this.reverter.revertFromAssert()));
     });
@@ -77,10 +73,6 @@ describe('expectRevert', function () {
 
     it('accepts a failed requirement with reason', async function () {
       await expectRevert.unspecified(this.reverter.revertFromRequireWithReason());
-    });
-
-    it('accepts a throw', async function () {
-      await expectRevert.unspecified(this.reverter.revertFromThrow());
     });
 
     it('rejects a failed assertion', async function () {
@@ -113,10 +105,6 @@ describe('expectRevert', function () {
       await assertFailure(expectRevert.assertion(this.reverter.revertFromRequireWithReason()));
     });
 
-    it('rejects a throw', async function () {
-      await assertFailure(expectRevert.assertion(this.reverter.revertFromThrow()));
-    });
-
     it('accepts a failed assertion', async function () {
       await expectRevert.assertion(this.reverter.revertFromAssert());
     });
@@ -145,10 +133,6 @@ describe('expectRevert', function () {
 
     it('rejects a failed requirement with reason', async function () {
       await assertFailure(expectRevert.outOfGas(this.reverter.revertFromRequireWithReason()));
-    });
-
-    it('rejects a throw', async function () {
-      await assertFailure(expectRevert.outOfGas(this.reverter.revertFromThrow()));
     });
 
     it('accepts a failed assertion', async function () {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -9,7 +9,7 @@ module.exports = {
 
   compilers: {
     solc: {
-      version: '0.4.24',
+      version: '0.5.8',
     },
   },
 };


### PR DESCRIPTION
The helpers were being tested against contracts compiled with 0.4.24, this updates that to 0.5.8. We could also do tests against multiple versions, but that might be a bit overkill: simply targeting a reasonably recent one should be enough.