### PR TITLE
improve expectRevert output

### DIFF
--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -3,7 +3,6 @@ const { expect } = require('chai');
 
 const colors = require('ansi-colors');
 const semver = require('semver');
-const AssertionError = require('assert').AssertionError;
 
 async function expectException (promise, expectedError) {
   try {

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -2,13 +2,15 @@ const { web3 } = require('./setup');
 
 const colors = require('ansi-colors');
 const semver = require('semver');
+const assert = require('assert');
 
 async function expectException (promise, expectedError) {
   try {
     await promise;
   } catch (error) {
     if (error.message.indexOf(expectedError) === -1) {
-      throw Error(`Wrong failure type, expected '${expectedError}' and got '${error.message}'`);
+      const actualError = error.message.replace('Returned error: VM Exception while processing transaction: ', '');
+      assert.fail(`Wrong failure type, expected '${expectedError}' and got '${actualError}'`);
     }
     return;
   }

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -2,7 +2,7 @@ const { web3 } = require('./setup');
 
 const colors = require('ansi-colors');
 const semver = require('semver');
-const assert = require('assert');
+const AssertionError = require('assert').AssertionError;
 
 async function expectException (promise, expectedError) {
   try {
@@ -10,7 +10,11 @@ async function expectException (promise, expectedError) {
   } catch (error) {
     if (error.message.indexOf(expectedError) === -1) {
       const actualError = error.message.replace('Returned error: VM Exception while processing transaction: ', '');
-      assert.fail(`Wrong failure type, expected '${expectedError}' and got '${actualError}'`);
+      throw new AssertionError({
+        message: 'Wrong failure type',
+        expected: expectedError,
+        actual: actualError,
+      });
     }
     return;
   }

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -1,4 +1,5 @@
 const { web3 } = require('./setup');
+const { expect } = require('chai');
 
 const colors = require('ansi-colors');
 const semver = require('semver');
@@ -10,16 +11,12 @@ async function expectException (promise, expectedError) {
   } catch (error) {
     if (error.message.indexOf(expectedError) === -1) {
       const actualError = error.message.replace('Returned error: VM Exception while processing transaction: ', '');
-      throw new AssertionError({
-        message: 'Wrong failure type',
-        expected: expectedError,
-        actual: actualError,
-      });
+      expect.fail(actualError, expectedError, 'Wrong kind of exception received');
     }
     return;
   }
 
-  throw Error('Expected failure not received');
+  expect.fail('Expected an exception but none was received');
 }
 
 const expectRevert = async function (promise, expectedError) {

--- a/test/helpers/assertFailure.js
+++ b/test/helpers/assertFailure.js
@@ -5,10 +5,7 @@ async function assertFailure (promise) {
   try {
     await promise;
   } catch (error) {
-    if (error instanceof AssertionError) {
-      expect(error.message).to.equal('Wrong failure type');
-    }
-    return;
+    return error;
   }
   expect.fail();
 }

--- a/test/helpers/assertFailure.js
+++ b/test/helpers/assertFailure.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const AssertionError = require('assert').AssertionError;
 
 async function assertFailure (promise) {
   try {

--- a/test/helpers/assertFailure.js
+++ b/test/helpers/assertFailure.js
@@ -1,9 +1,13 @@
 const { expect } = require('chai');
+const AssertionError = require('assert').AssertionError;
 
 async function assertFailure (promise) {
   try {
     await promise;
   } catch (error) {
+    if (error instanceof AssertionError) {
+      expect(error.message).to.equal('Wrong failure type');
+    }
     return;
   }
   expect.fail();

--- a/test/src/expectRevert.test.js
+++ b/test/src/expectRevert.test.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai');
+
 const assertFailure = require('../helpers/assertFailure');
 const expectRevert = require('../../src/expectRevert');
 
@@ -10,7 +12,10 @@ describe('expectRevert', function () {
 
   describe('expectRevert', function () {
     it('rejects if no revert occurs', async function () {
-      await assertFailure(expectRevert(this.reverter.dontRevert()));
+      const assertion =
+        await assertFailure(expectRevert(this.reverter.dontRevert(), 'reason'));
+
+      expect(assertion.message).to.equal('Expected an exception but none was received');
     });
 
     it('rejects a revert', async function () {
@@ -22,7 +27,10 @@ describe('expectRevert', function () {
     });
 
     it('rejects a revert with incorrect expected reason', async function () {
-      await assertFailure(expectRevert(this.reverter.revertFromRevertWithReason(), 'Wrong reason'));
+      const assertion =
+        await assertFailure(expectRevert(this.reverter.revertFromRevertWithReason(), 'Wrong reason'));
+
+      expect(assertion.message).to.equal('Wrong kind of exception received');
     });
 
     it('accepts a revert with correct expected reason', async function () {


### PR DESCRIPTION
fixes #33 

- use `AssertionError` instead of plain `Error` as @frangio suggestion 
- remove noisy `Returned error: VM Exception while processing transaction: ` error substring from `error.message`