### PR TITLE
Don't warn about Ganache's version if not used

### DIFF
--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -33,21 +33,24 @@ if your \'require\' statement doesn\'t have one.');
   // Find out if current version of ganache-core supports revert reason i.e >= 2.2.0.
   // https://github.com/trufflesuite/ganache-core/releases/tag/v2.2.0
   const nodeInfo = await web3.eth.getNodeInfo();
-  const matches = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
+  const isGanache = nodeInfo.includes('TestRPC') && nodeInfo.includes('ethereum-js');
 
-  const warn = function (msg) {
-    console.log(`${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} \
-      expectRevert: ` + msg);
-  };
+  if (isGanache) {
+    const matches = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
+    const warn = function (msg) {
+      console.log(`${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} \
+        expectRevert: ` + msg);
+    };
 
-  if (matches === null || !(1 in matches)) {
-    // warn users and skip reason check.
-    warn('revert reason checking only supported on Ganache v2.2.0 or newer.');
-    expectedError = 'revert';
-  } else if (!semver.gte(matches[1], '2.2.0')) {
-    // warn users and skip reason check.
-    warn(`current version of Ganache (v${matches[1]}) doesn't return revert reason. Use v2.2.0 or newer.`);
-    expectedError = 'revert';
+    if (matches === null || !(1 in matches)) {
+      // warn users and skip reason check.
+      warn('revert reason checking only supported on Ganache v2.2.0 or newer.');
+      expectedError = 'revert';
+    } else if (!semver.gte(matches[1], '2.2.0')) {
+      // warn users and skip reason check.
+      warn(`current version of Ganache (v${matches[1]}) doesn't return revert reason. Use v2.2.0 or newer.`);
+      expectedError = 'revert';
+    }
   }
 
   await expectException(promise, expectedError);


### PR DESCRIPTION
This PR disables the Ganache version warning if Ganache isn't used.

I couldn't find any test related to this warning, so this PR has no tests either :(