### PR TITLE
Cache nodeInfo calls made from expectRevert

### DIFF
--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const colors = require('ansi-colors');
 const semver = require('semver');
 
-let nodeInfo;
+let nodeInfo; // We cache the result for performance
 
 async function expectException (promise, expectedError) {
   try {

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -4,6 +4,8 @@ const { expect } = require('chai');
 const colors = require('ansi-colors');
 const semver = require('semver');
 
+let nodeInfo;
+
 async function expectException (promise, expectedError) {
   try {
     await promise;
@@ -32,7 +34,9 @@ if your \'require\' statement doesn\'t have one.');
 
   // Find out if current version of ganache-core supports revert reason i.e >= 2.2.0.
   // https://github.com/trufflesuite/ganache-core/releases/tag/v2.2.0
-  const nodeInfo = await web3.eth.getNodeInfo();
+  if (nodeInfo === undefined) {
+    nodeInfo = await web3.eth.getNodeInfo();
+  }
   const matches = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
 
   const warn = function (msg) {


### PR DESCRIPTION
I suggested this change to @frangio some time ago, as I found that Open Zepellin Contract's test suite makes a lot of `web3_clientVersion`. 

It just cache's the value returned by `web3.eth.getNodeInfo()` using a global variable.

This only has an impact on large codebases, so feel free to ignore this PR if you don't think it's worth it.