### PR TITLE
Scope npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.5.0 (unreleased)
+ * Renamed the package to `@openzeppelin/test-helpers`. ([#78](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/78))
  * Removed hard-dependency on `truffle-contract` ([#75](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/75)):
    * An `environment` option was added to `configure`, and can be set to either `web3` or `truffle` (default is `web3`, but there is automatic detection of a `truffle` environment)
    * `singletons` return [`web3 Contract`](https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html) instances when `environment` is set to `web3`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenZeppelin Test Helpers
 
-[![NPM Package](https://img.shields.io/npm/v/openzeppelin-test-helpers.svg)](https://www.npmjs.org/package/openzeppelin-test-helpers)
+[![NPM Package](https://img.shields.io/npm/v/@openzeppelin/test-helpers.svg)](https://www.npmjs.org/package/@openzeppelin/test-helpers)
 [![Build Status](https://travis-ci.com/OpenZeppelin/openzeppelin-test-helpers.svg?branch=master)](https://travis-ci.com/OpenZeppelin/openzeppelin-test-helpers)
 
 **JavaScript testing helpers for Ethereum smart contract development.** These use [web3 1.2](https://www.npmjs.com/package/web3) under the hood, and include support for [`truffle-contract`](https://www.npmjs.com/package/@truffle/contract) objects. [Chai](http://chaijs.com/) [bn.js](https://github.com/indutny/bn.js) assertions using [chai-bn](https://github.com/OpenZeppelin/chai-bn) are also included.
@@ -8,14 +8,14 @@
 ## Installation
 
 ```bash
-npm install --save-dev openzeppelin-test-helpers chai
+npm install --save-dev @openzeppelin/test-helpers chai
 ```
 
 ## Usage
 
 ```javascript
-// Import all required modules from openzeppelin-test-helpers
-const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+// Import all required modules from @openzeppelin/test-helpers
+const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 
 // Import preferred chai flavor: both expect and should are supported
 const { expect } = require('chai');
@@ -56,7 +56,7 @@ This library features support for both web3 and truffle contract instances. The 
 While automatic detection should cover most use cases, both the environment and provider can be manually supplied:
 
 ```javascript
-require('openzeppelin-test-helpers/configure')({ environment: 'web3', provider: 'http://localhost:8080' });
+require('@openzeppelin/test-helpers/configure')({ environment: 'web3', provider: 'http://localhost:8080' });
 
 const { expectEvent } = require('openzeppelin-test-helpers');
 ```
@@ -185,7 +185,7 @@ contract Owned {
 
 Can be tested as follows:
 ```javascript
-const { expectRevert } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('@openzeppelin/test-helpers');
 
 const Owned = artifacts.require('Owned');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "openzeppelin-test-helpers",
+  "name": "@openzeppelin/test-helpers",
   "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openzeppelin-test-helpers",
+  "name": "@openzeppelin/test-helpers",
   "version": "0.4.3",
   "description": "JavaScript testing helpers for Ethereum smart contract development.",
   "main": "index.js",

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -54,10 +54,10 @@ push_and_publish() {
   push_release_branch_and_tag
 
   log "Publishing package on npm"
-  npm publish --tag "$dist_tag" --otp "$(prompt_otp)"
+  npm publish --tag "$dist_tag" --otp "$(prompt_otp)" --access=public
 
   if [[ "$dist_tag" == "latest" ]]; then
-    npm dist-tag rm --otp "$(prompt_otp)" openzeppelin-test-helpers next
+    npm dist-tag rm --otp "$(prompt_otp)" @openzeppelin/test-helpers next
   fi
 }
 

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -40,7 +40,7 @@ if your \'require\' statement doesn\'t have one.');
   const matches = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
 
   const warn = function (msg) {
-    console.log(`${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} \
+    console.log(`${colors.white.bgBlack('@openzeppelin/test-helpers')} ${colors.black.bgYellow('WARN')} \
       expectRevert: ` + msg);
   };
 

--- a/test-integration/ganache-core-2.1.x/test/Tested.test.js
+++ b/test-integration/ganache-core-2.1.x/test/Tested.test.js
@@ -1,4 +1,4 @@
-const { expectRevert } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
 const Tested = artifacts.require('Tested');

--- a/test-integration/simple-project-truffle-template/test/Tested.test.js
+++ b/test-integration/simple-project-truffle-template/test/Tested.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 
 const Tested = artifacts.require('Tested');
 

--- a/test-integration/simple-project-truffle-template/test/accounts.test.js
+++ b/test-integration/simple-project-truffle-template/test/accounts.test.js
@@ -1,4 +1,4 @@
-const { balance, BN, ether, send } = require('openzeppelin-test-helpers');
+const { balance, BN, ether, send } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
 contract('accounts', function (accounts) {

--- a/test-integration/truffle-migration/migrations/1_initial_migration.js
+++ b/test-integration/truffle-migration/migrations/1_initial_migration.js
@@ -4,7 +4,7 @@ module.exports = function(deployer) {
   deployer.deploy(Migrations);
 
   try {
-    require('openzeppelin-test-helpers/configure')({ provider: web3.currentProvider });
+    require('@openzeppelin/test-helpers/configure')({ provider: web3.currentProvider });
 
     console.error('Successfully configured Web3 instance');
   } catch (e) {

--- a/test-integration/truffle-migration/migrations/1_initial_migration.js
+++ b/test-integration/truffle-migration/migrations/1_initial_migration.js
@@ -4,7 +4,7 @@ module.exports = function(deployer) {
   deployer.deploy(Migrations);
 
   try {
-    require('@openzeppelin-test-helpers/configure')({ provider: web3.currentProvider, environment: 'truffle' });
+    require('@openzeppelin/test-helpers/configure')({ provider: web3.currentProvider, environment: 'truffle' });
 
     console.error('Successfully configured Web3 instance');
   } catch (e) {

--- a/test-integration/truffle-migration/migrations/2_test_send.js
+++ b/test-integration/truffle-migration/migrations/2_test_send.js
@@ -1,5 +1,5 @@
 module.exports = async function(deployer, network, accounts) {
-  const { send } = require('openzeppelin-test-helpers');
+  const { send } = require('@openzeppelin/test-helpers');
 
   await send.ether(accounts[0], accounts[1], 1);
 

--- a/test-integration/truffle-migration/migrations/3_test_singleton.js
+++ b/test-integration/truffle-migration/migrations/3_test_singleton.js
@@ -1,5 +1,5 @@
 module.exports = async function(deployer, network, accounts) {
-  const { singletons } = require('openzeppelin-test-helpers');
+  const { singletons } = require('@openzeppelin/test-helpers');
 
   await singletons.ERC1820Registry(accounts[0]);
 


### PR DESCRIPTION
This changes the package from `openzeppelin-test-helpers` to `@openzeppelin/test-helpers`. Once 0.5.0 is published under this new name, we should deprecate the old package. I'm not sure yet if we should also publish 0.5.0 with the old name.