### PR TITLE
Improve node mismatch warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    * An `environment` option was added to `configure`, and can be set to either `web3` or `truffle` (default is `web3`, but there is automatic detection of a `truffle` environment)
    * `singletons` return [`web3 Contract`](https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html) instances when `environment` is set to `web3`
    * `expectEvent.inLogs` was deprecated in favor of `expectEvent`, which receives the full receipt object (not just the logs), and supports both web3 and truffle contract receipts
+ * Improved how revert reason checks (`expectRevert`) are handled on unsupported environments. ([#80](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/80))
  * Breaking: `configure`'s `web3` argument was removed and replaced by `provider`, which can be either a web3 provider or a connection string. The default is `http://localhost:8545`, unless a global `web3` instance is found, in which case `web3.currentProvider` is used.
 
 ### How to upgrade from 0.4

--- a/src/expectRevert.js
+++ b/src/expectRevert.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const colors = require('ansi-colors');
 const semver = require('semver');
 
-let nodeInfo; // We cache the result for performance
+const checkedProviders = new WeakSet();
 
 async function expectException (promise, expectedError) {
   try {
@@ -25,34 +25,51 @@ async function expectException (promise, expectedError) {
   expect.fail('Expected an exception but none was received');
 }
 
+async function checkRevertReasonSupport (provider) {
+  if (!checkedProviders.has(provider)) {
+    // Find out if the provider supports revert reasons.
+    // Implementations with known support:
+    //  * ganache-core (TestRPC) >=2.2.0 (https://github.com/trufflesuite/ganache-core/releases/tag/v2.2.0)
+
+    const nodeInfo = await web3.eth.getNodeInfo();
+    const ganacheVersion = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
+
+    const warn = function (msg) {
+      console.log(`\
+${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} expectRevert: ${msg}`
+      );
+    };
+
+    if (ganacheVersion === null) {
+      warn(`\
+Assertions may yield false negatives!
+
+Revert reason checks are only known to work on Ganache >=2.2.0, and the current node is ${nodeInfo}.
+
+If your node does support revert reasons, please let us know: \
+https://github.com/OpenZeppelin/openzeppelin-test-helpers/issues/new`
+      );
+    } else if (!semver.gte(ganacheVersion[1], '2.2.0')) {
+      throw new Error(`\
+The current version of Ganache (v${ganacheVersion[1]}) doesn't return revert reasons.
+
+Upgrade to v2.2.0 or newer, or use expectRevert.unspecified to skip the revert reason check.`
+      );
+    }
+
+    checkedProviders.add(provider);
+  }
+}
+
 const expectRevert = async function (promise, expectedError) {
+  promise.catch(() => { }); // Avoids uncaught promise rejections in case an input validation causes us to return early
+
   if (!expectedError) {
-    promise.catch(() => { });
     throw Error('No revert reason specified: call expectRevert with the reason string, or use expectRevert.unspecified \
 if your \'require\' statement doesn\'t have one.');
   }
 
-  // Find out if current version of ganache-core supports revert reason i.e >= 2.2.0.
-  // https://github.com/trufflesuite/ganache-core/releases/tag/v2.2.0
-  if (nodeInfo === undefined) {
-    nodeInfo = await web3.eth.getNodeInfo();
-  }
-  const matches = /TestRPC\/v([\w.-]+)\/ethereum-js/.exec(nodeInfo);
-
-  const warn = function (msg) {
-    console.log(`${colors.white.bgBlack('openzeppelin-test-helpers')} ${colors.black.bgYellow('WARN')} \
-      expectRevert: ` + msg);
-  };
-
-  if (matches === null || !(1 in matches)) {
-    // warn users and skip reason check.
-    warn('revert reason checking only supported on Ganache v2.2.0 or newer.');
-    expectedError = 'revert';
-  } else if (!semver.gte(matches[1], '2.2.0')) {
-    // warn users and skip reason check.
-    warn(`current version of Ganache (v${matches[1]}) doesn't return revert reason. Use v2.2.0 or newer.`);
-    expectedError = 'revert';
-  }
+  await checkRevertReasonSupport(web3.currentProvider);
 
   await expectException(promise, expectedError);
 };

--- a/test-integration/ganache-core-2.1.x/test/Tested.test.js
+++ b/test-integration/ganache-core-2.1.x/test/Tested.test.js
@@ -7,26 +7,25 @@ contract('Tested', function (accounts) {
   context('expectRevert', async function () {
     beforeEach(async function () {
       this.contract = await Tested.new();
-    })
+    });
 
     context('with ganache-core < 2.2.0', async function () {
-      it('accepts reverts without regard to the specified reason', async function () {
-        // This is the revert reason at Tested.sol:5
-        const expectedMessage = 'lorem ipsum';
+      it('throws when specifying a revert reason', async function () {
         // Asserting that locally installed ganache-core is v2.1.0.
         const nodeInfo = await web3.eth.getNodeInfo();
         expect(nodeInfo).to.include('2.1.0');
+
         try {
-          await this.contract.failWithRevertReason();
+          await expectRevert(this.contract.failWithRevertReason(), 'lorem ipsum');
+          expect.fail('expectRevert did not throw');
+        } catch (e) {
+          expect(e.message).to.include(`doesn't return revert reasons`);
         }
-        catch (error) {
-          // Asserting that older ganache does NOT return reason message.
-          expect(error.message).to.not.include(expectedMessage);
-        }
-        // With that said, following revert should be accepted without regard to the specified
-        // reason message.
-        await expectRevert(this.contract.failWithRevertReason(), expectedMessage);
-      })
-    })
-  })
+      });
+
+      it('works when using expectRevert.unspecified', async function () {
+        await expectRevert.unspecified(this.contract.failWithRevertReason());
+      });
+    });
+  });
 });


### PR DESCRIPTION
Supercedes https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/73

We now:
 - emit a warning but carry on when running with unknown nodes
 - throw an error when using revert reasons on older ganache versions