### PR TITLE
Make chai a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -302,8 +302,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -607,7 +606,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -642,8 +640,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chownr": {
       "version": "1.1.2",
@@ -973,7 +970,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -2259,8 +2255,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -3275,8 +3270,7 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -4142,8 +4136,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "release": "scripts/release/release.sh",
     "test": "./scripts/test.sh --network ganache",
-    "test-integration": "./test-integration/run-all.sh",
+    "test-integration": "bash -x test-integration/run-all.sh",
     "version": "scripts/release/update-changelog-release-date.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@truffle/contract": "^4.0.35",
     "ansi-colors": "^3.2.3",
+    "chai": "^4.2.0",
     "chai-bn": "^0.2.0",
     "ethjs-abi": "^0.2.1",
     "lodash.flatten": "^4.4.0",
@@ -46,7 +47,6 @@
   },
   "devDependencies": {
     "@openzeppelin/contract-loader": "^0.1.0",
-    "chai": "^4.2.0",
     "eslint": "^5.9.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
@@ -56,8 +56,5 @@
     "eslint-plugin-standard": "^4.0.0",
     "ganache-cli": "^6.5.0",
     "truffle": "^5.0.29"
-  },
-  "peerDependencies": {
-    "chai": "^4.2.0"
   }
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -2,10 +2,20 @@ require('../configure')();
 
 const web3 = require('./config/web3').getWeb3();
 
-const chai = require('chai');
 const BN = web3.utils.BN;
+const chaiBN = require('chai-bn')(BN);
 
-chai.use(require('chai-bn')(BN));
+require('chai').use(chaiBN);
+
+// Installing chai-bn for the user is part of the offering.
+//
+// The chai module used internally by us may not be the same one that the user
+// has in their own tests. This can happen if the version ranges required don't
+// intersect, or if the package manager doesn't dedupe the modules for any
+// other reason. We do our best to install chai-bn for the user.
+function useChaiBN (chai) { if (chai) chai.use(chaiBN); }
+useChaiBN(require.main.require('chai'));
+useChaiBN(module.parent.require('chai'));
 
 module.exports = {
   web3,

--- a/test-integration/chai-bn/package-lock.json
+++ b/test-integration/chai-bn/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "chai-bn",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+        }
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+    }
+  }
+}

--- a/test-integration/chai-bn/package.json
+++ b/test-integration/chai-bn/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "chai-bn",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node test.js"
+  },
+  "author": "Francisco Giordano <frangio.1@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "chai": "^3.5.0",
+    "semver": "^6.3.0"
+  }
+}

--- a/test-integration/chai-bn/run.sh
+++ b/test-integration/chai-bn/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+
+cd "$(dirname $0)"
+
+# Get a package like a user would install
+pkg="$(npm pack ../../ 2> /dev/null)"
+
+# Clean it up afterwards
+trap "rm -f $pkg" EXIT
+
+npm install
+
+npm install --no-save "$pkg"
+
+npm test

--- a/test-integration/chai-bn/test.js
+++ b/test-integration/chai-bn/test.js
@@ -1,0 +1,23 @@
+// Validate that this is testing what we want: that this package uses a
+// different chai module than the one being used internally by test-helpers.
+// This is verified by checking that the chai versions don't intersect, so that
+// the package manager is unable to dedupe them.
+const assert = require('assert');
+const semver = require('semver');
+
+const our = require('./package.json');
+const testHelpers = require('@openzeppelin/test-helpers/package.json');
+
+assert(
+  !semver.intersects(our.dependencies.chai, testHelpers.dependencies.chai),
+  'Integration test is not set up correctly: chai module may be deduped',
+);
+
+// Even though we're using different chai modules, chai-bn is still being
+// installed.
+require('@openzeppelin/test-helpers');
+
+const { expect } = require('chai');
+
+// If chai-bn is not installed the following line will fail.
+expect('1').to.bignumber.equal('1');

--- a/test-integration/run-all.sh
+++ b/test-integration/run-all.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-./test-integration/simple-project-truffle-5.0.1/run.sh
-./test-integration/simple-project-truffle-web3-1.2.0/run.sh
-./test-integration/ganache-core-2.1.x/run.sh
-./test-integration/truffle-migration/run.sh
+for test in "$(dirname $0)"/**; do
+  bash "$test/run.sh"
+done


### PR DESCRIPTION
Fixes #32, the longstanding issue that users have to install `chai` side by side with `test-helpers` for basically no reason.

I made `chai` a proper dependency as opposed to a peer dependency, and added code to install `chai-bn` for the user if the version of the module they're using is different than ours.

Would love to get this into 0.5 as soon as possible. :slightly_smiling_face: 