### PR TITLE
feat: event-not-emitted support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.5.6 (TBD)
- * `expectEvent.not` deprecated and moved to `expectEvent.notEmitted` ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
- * Added `expectEvent.notEmitted()` for test negative cases using truffle receipt ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
+## 0.5.6 (unreleased)
+ * Deprecated `expectEvent.not` in favor of `expectEvent.notEmitted`. ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
+ * Added `expectEvent.notEmitted()` for asserting absence of events in Truffle or Web3 receipts. ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
 
 ## 0.5.5 (2020-03-12)
  * Added function `advanceBlockTo`. ([#94](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/94))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.6 (TBD)
+ * `expectEvent.not` deprecated and moved to `expectEvent.notEmitted` ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
+ * Added `expectEvent.notEmitted()` for test negative cases using truffle receipt ([#121](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/121))
+
 ## 0.5.5 (2020-03-12)
  * Added function `advanceBlockTo`. ([#94](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/94))
  * Added `expectEvent.not` support to test negative cases. ([#104](https://github.com/OpenZeppelin/openzeppelin-test-helpers/pull/104))

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -175,7 +175,7 @@ Same as `inTransaction`, but for events emitted during the construction of `emit
 
 === `notEmitted`
 
-In order to test that an event was not emitted there is `expectEvent.notEmitted`, there are several variants that follow API of previously mentioned functions:
+In order to test that an event was not emitted there is `expectEvent.notEmitted`. There are several variants that follow the API of previously mentioned functions:
 
  - `expectEvent.notEmitted(receipt, eventName)` similar to `expectEvent()`
  - `expectEvent.notEmitted.inTransaction(txHash, emitter, eventName)` similar to `expectEvent.inTransaction()`

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -173,6 +173,14 @@ async function expectEvent.inConstruction(emitter, eventName, eventArgs = {})
 
 Same as `inTransaction`, but for events emitted during the construction of `emitter`. Note that this is currently only supported for truffle contracts.
 
+=== `notEmitted`
+
+In order to test that an event was not emitted there is `expectEvent.notEmitted`, there are several variants that follow API of previously mentioned functions:
+
+ - `expectEvent.notEmitted(receipt, eventName)` similar to `expectEvent()`
+ - `expectEvent.notEmitted.inTransaction(txHash, emitter, eventName)` similar to `expectEvent.inTransaction()`
+ - `expectEvent.notEmitted.inConstruction(emitter, eventName)` similar to `expectEvent.inConstruction()`
+
 [[expect-revert]]
 == `expectRevert`
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/OpenZeppelin/openzeppelin-test-helpers#readme",
   "dependencies": {
     "@openzeppelin/contract-loader": "^0.4.0",
-    "@truffle/contract": "^4.0.35",
+    "@truffle/contract": "^4.0.35 <4.2.2",
     "ansi-colors": "^3.2.3",
     "chai": "^4.2.0",
     "chai-bn": "^0.2.1",

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -184,11 +184,11 @@ expectEvent.notEmitted.inTransaction = notInTransaction;
 expectEvent.not = {};
 expectEvent.not.inConstruction = deprecate(
   notInConstruction,
-  "expectEvent.not is deprecated. Use expectEvent.notEmitted instead."
+  'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.'
 );
 expectEvent.not.inTransaction = deprecate(
   notInTransaction,
-  "expectEvent.not is deprecated. Use expectEvent.notEmitted instead."
+  'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.'
 );
 
 module.exports = expectEvent;

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -177,8 +177,10 @@ expectEvent.inLogs = deprecate(inLogs, 'expectEvent.inLogs() is deprecated. Use 
 expectEvent.inConstruction = inConstruction;
 expectEvent.inTransaction = inTransaction;
 
-expectEvent.not = {};
 expectEvent.notEmitted = notExpectEvent;
-expectEvent.not.inConstruction = notInConstruction;
-expectEvent.not.inTransaction = notInTransaction;
+expectEvent.notEmitted.inConstruction = notInConstruction;
+expectEvent.notEmitted.inTransaction = notInTransaction;
+
+expectEvent.not = deprecate(inLogs, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
+
 module.exports = expectEvent;

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -182,7 +182,13 @@ expectEvent.notEmitted.inConstruction = notInConstruction;
 expectEvent.notEmitted.inTransaction = notInTransaction;
 
 expectEvent.not = {};
-expectEvent.not.inConstruction = deprecate(notInConstruction, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
-expectEvent.not.inTransaction = deprecate(notInTransaction, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
+expectEvent.not.inConstruction = deprecate(
+  notInConstruction,
+  "expectEvent.not is deprecated. Use expectEvent.notEmitted instead."
+);
+expectEvent.not.inTransaction = deprecate(
+  notInTransaction,
+  "expectEvent.not is deprecated. Use expectEvent.notEmitted instead."
+);
 
 module.exports = expectEvent;

--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -181,6 +181,8 @@ expectEvent.notEmitted = notExpectEvent;
 expectEvent.notEmitted.inConstruction = notInConstruction;
 expectEvent.notEmitted.inTransaction = notInTransaction;
 
-expectEvent.not = deprecate(inLogs, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
+expectEvent.not = {};
+expectEvent.not.inConstruction = deprecate(notInConstruction, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
+expectEvent.not.inTransaction = deprecate(notInTransaction, 'expectEvent.not is deprecated. Use expectEvent.notEmitted instead.');
 
 module.exports = expectEvent;

--- a/test/src/expectEvent.truffle.test.js
+++ b/test/src/expectEvent.truffle.test.js
@@ -505,13 +505,13 @@ contract('expectEvent (truffle contracts)', function ([deployer]) {
           this.txHash = receipt.transactionHash;
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event does not exist in ABI', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'Nonexistant'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'Nonexistant'));
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'Argumentless'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'Argumentless'));
         });
       });
       context('with arguments', function () {
@@ -521,10 +521,10 @@ contract('expectEvent (truffle contracts)', function ([deployer]) {
           this.txHash = receipt.transactionHash;
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'ShortUint'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'ShortUint'));
         });
       });
       context('with events emitted by an indirectly called contract', function () {
@@ -534,24 +534,26 @@ contract('expectEvent (truffle contracts)', function ([deployer]) {
           this.txHash = receipt.transactionHash;
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, IndirectEventEmitter, 'IndirectString'));
+          await assertFailure(
+            expectEvent.notEmitted.inTransaction(this.txHash, IndirectEventEmitter, 'IndirectString')
+          );
         });
       });
     });
     describe('inConstructor', function () {
       it('accepts not emitted events', async function () {
-        await expectEvent.not.inConstruction(this.emitter, 'WillNeverBeEmitted');
+        await expectEvent.notEmitted.inConstruction(this.emitter, 'WillNeverBeEmitted');
       });
       it('throws when event does not exist in ABI', async function () {
-        await assertFailure(expectEvent.not.inConstruction(this.emitter, 'Nonexistant'));
+        await assertFailure(expectEvent.notEmitted.inConstruction(this.emitter, 'Nonexistant'));
       });
       it('throws when event its emitted', async function () {
-        await assertFailure(expectEvent.not.inConstruction(this.emitter, 'ShortUint'));
-        await assertFailure(expectEvent.not.inConstruction(this.emitter, 'Boolean'));
-        await assertFailure(expectEvent.not.inConstruction(this.emitter, 'String'));
+        await assertFailure(expectEvent.notEmitted.inConstruction(this.emitter, 'ShortUint'));
+        await assertFailure(expectEvent.notEmitted.inConstruction(this.emitter, 'Boolean'));
+        await assertFailure(expectEvent.notEmitted.inConstruction(this.emitter, 'String'));
       });
     });
   });

--- a/test/src/expectEvent.truffle.test.js
+++ b/test/src/expectEvent.truffle.test.js
@@ -485,6 +485,19 @@ contract('expectEvent (truffle contracts)', function ([deployer]) {
   });
 
   describe('not', function () {
+    describe('notEmitted', function () {
+      beforeEach(async function () {
+        this.receipt = await this.emitter.emitArgumentless();
+      });
+
+      it('accepts not-emitted events', function () {
+        expectEvent.notEmitted(this.receipt, 'UnemittedEvent');
+      });
+
+      it('throws if an emitted event is requested', function () {
+        expect(() => expectEvent.notEmitted(this.receipt, 'Argumentless')).to.throw();
+      });
+    });
     describe('inTransaction', function () {
       context('with no arguments', function () {
         beforeEach(async function () {

--- a/test/src/expectEvent.web3.test.js
+++ b/test/src/expectEvent.web3.test.js
@@ -453,13 +453,13 @@ contract('expectEvent (web3 contracts) ', function ([deployer]) {
           ({ transactionHash: this.txHash } = await this.emitter.methods.emitArgumentless().send());
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event does not exist in ABI', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'Nonexistant'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'Nonexistant'));
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'Argumentless'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'Argumentless'));
         });
       });
       context('with arguments', function () {
@@ -468,10 +468,10 @@ contract('expectEvent (web3 contracts) ', function ([deployer]) {
           ({ transactionHash: this.txHash } = await this.emitter.methods.emitShortUint(this.value).send());
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, EventEmitter, 'ShortUint'));
+          await assertFailure(expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'ShortUint'));
         });
       });
       context('with events emitted by an indirectly called contract', function () {
@@ -482,16 +482,18 @@ contract('expectEvent (web3 contracts) ', function ([deployer]) {
           ).send());
         });
         it('accepts not emitted events', async function () {
-          await expectEvent.not.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
+          await expectEvent.notEmitted.inTransaction(this.txHash, EventEmitter, 'WillNeverBeEmitted');
         });
         it('throws when event its emitted', async function () {
-          await assertFailure(expectEvent.not.inTransaction(this.txHash, IndirectEventEmitter, 'IndirectString'));
+          await assertFailure(
+            expectEvent.notEmitted.inTransaction(this.txHash, IndirectEventEmitter, 'IndirectString')
+          );
         });
       });
     });
     describe('inConstruction', function () {
       it('is unsupported', async function () {
-        await assertFailure(expectEvent.not.inConstruction(this.emitter, 'ShortUint'));
+        await assertFailure(expectEvent.notEmitted.inConstruction(this.emitter, 'ShortUint'));
       });
     });
   });

--- a/test/src/expectEvent.web3.test.js
+++ b/test/src/expectEvent.web3.test.js
@@ -434,6 +434,19 @@ contract('expectEvent (web3 contracts) ', function ([deployer]) {
   });
 
   describe('not', function () {
+    describe('notEmitted', function () {
+      beforeEach(async function () {
+        this.receipt = await this.emitter.methods.emitArgumentless().send();
+      });
+
+      it('accepts not-emitted events', function () {
+        expectEvent.notEmitted(this.receipt, 'UnemittedEvent');
+      });
+
+      it('throws if an emitted event is requested', function () {
+        expect(() => expectEvent.notEmitted(this.receipt, 'Argumentless')).to.throw();
+      });
+    });
     describe('inTransaction', function () {
       context('with no arguments', function () {
         beforeEach(async function () {

--- a/test/src/expectRevert.test.js
+++ b/test/src/expectRevert.test.js
@@ -149,7 +149,7 @@ describe('expectRevert', function () {
       await assertFailure(expectRevert.outOfGas(this.reverter.revertFromAssert()));
     });
 
-    it('accets an outOfGas', async function () {
+    it('accepts an outOfGas', async function () {
       await expectRevert.outOfGas(this.reverter.revertFromOutOfGas({ gas: 2000000 }));
     });
   });


### PR DESCRIPTION
Support for `expectEvent.notEmitted()`. 

**Question:** Should there be support for argument specification? If so, how should be handled empty args? Should it search for an empty args event or just generally assert if an event was not-emitted?

Closes #120 

I will work on changelog/docs after finalizing API/behavior.