### PR TITLE
return event from expectEvent

### DIFF
--- a/src/expectEvent.js
+++ b/src/expectEvent.js
@@ -24,9 +24,9 @@ function expectEvent (receipt, eventName, eventArgs = {}) {
       }
     }));
 
-    inLogs(logs, eventName, eventArgs);
+    return inLogs(logs, eventName, eventArgs);
   } else if (isTruffleReceipt(receipt)) {
-    inLogs(receipt.logs, eventName, eventArgs);
+    return inLogs(receipt.logs, eventName, eventArgs);
   } else {
     throw new Error('Unknown transaction receipt object');
   }

--- a/test/src/expectEvent.truffle.test.js
+++ b/test/src/expectEvent.truffle.test.js
@@ -102,6 +102,10 @@ contract('expectEvent (truffle contracts)', function ([deployer]) {
         expectEvent(this.receipt, 'Argumentless');
       });
 
+      it('returns the event', function () {
+        expect(expectEvent(this.receipt, 'Argumentless').event).to.equal('Argumentless');
+      });
+
       it('throws if an unemitted event is requested', function () {
         expect(() => expectEvent(this.receipt, 'UnemittedEvent')).to.throw();
       });

--- a/test/src/expectEvent.web3.test.js
+++ b/test/src/expectEvent.web3.test.js
@@ -44,6 +44,10 @@ contract('expectEvent (web3 contracts) ', function ([deployer]) {
         expectEvent(this.receipt, 'Argumentless');
       });
 
+      it('returns the event', function () {
+        expect(expectEvent(this.receipt, 'Argumentless').event).to.equal('Argumentless');
+      });
+
       it('throws if an unemitted event is requested', function () {
         expect(() => expectEvent(this.receipt, 'UnemittedEvent')).to.throw();
       });


### PR DESCRIPTION
This updates the expectEvent helper to return the found event, so we can make further assertions on it.