### PR TITLE
Fix expectRevert accepting partial matches

### DIFF
--- a/test/src/expectRevert.test.js
+++ b/test/src/expectRevert.test.js
@@ -51,6 +51,10 @@ describe('expectRevert', function () {
       await assertFailure(expectRevert(this.reverter.revertFromRequireWithReason(), 'Wrong reason'));
     });
 
+    it('rejects a failed requirement with partial error message match', async function () {
+      await assertFailure(expectRevert(this.reverter.revertFromRequireWithReason(), 'VM'));
+    });
+
     it('accepts a failed requirement with correct expected reason', async function () {
       await expectRevert(this.reverter.revertFromRequireWithReason(), 'Failed requirement');
     });


### PR DESCRIPTION
The bug caused tests using `expectRevert` to pass despite the revertReason not fully being correct because of the use of `String.prototype.indexOf` to verify if the correct revert reason was contained in the error string. To fix it more robust error parsing logic was added; it is compatible with both old and new VM Exception strings.

Discovered this bug in my personal project, tests were passing despite the revert messages not fully being identical.