### PR TITLE
Remove gas price 0 to support deployment on a chain post-London fork

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -22,7 +22,7 @@ async function transaction (target, name, argsTypes, argsValues, opts = {}) {
 }
 
 function ether (from, to, value) {
-  return web3.eth.sendTransaction({ from, to, value, gasPrice: 0 });
+  return web3.eth.sendTransaction({ from, to, value });
 }
 
 module.exports = {


### PR DESCRIPTION
eip-1559 breaks gasPrice: 0 transactions - they get stuck in pending in geth

this fixes that by removing gasPrice: 0.

i'm not sure if this has any unwanted side-effects for users that are deploying to non-eip-1559 chains like local truffle/hardhat, and I haven't tested that, but it fixes issues with deploying to geth :)